### PR TITLE
Add Info about new versions of GCC not working with setup tools.

### DIFF
--- a/docs/support-tools/setting-up.md
+++ b/docs/support-tools/setting-up.md
@@ -49,7 +49,8 @@ If the setup worked correctly, the following executables will be created:
 - **xsm** in `$HOME/myexpos/xsm` folder
 
 !!! note
-    In newer versions of GCC (14+) when executing the ''' make ''' an error is thrown and the executables are not created. This can be fixed by downgrading GCC to     13 or lower.
+    In newer versions of GCC (14+) when executing the `make` an error is thrown and the executables are not created.
+    This can be fixed by downgrading GCC to 13 or lower.
 
 If the setting up of the system is done correctly the following directories will be created.
 

--- a/docs/support-tools/setting-up.md
+++ b/docs/support-tools/setting-up.md
@@ -49,7 +49,7 @@ If the setup worked correctly, the following executables will be created:
 - **xsm** in `$HOME/myexpos/xsm` folder
 
 !!! note
-    In newer versions of GCC (14+) when executing the `make` an error is thrown and the executables are not created.
+    In newer versions of GCC (14+) when executing the `make` command an error is thrown and the executables are not created.
     This can be fixed by downgrading GCC to 13 or lower.
 
 If the setting up of the system is done correctly the following directories will be created.

--- a/docs/support-tools/setting-up.md
+++ b/docs/support-tools/setting-up.md
@@ -48,6 +48,9 @@ If the setup worked correctly, the following executables will be created:
 - **xfs-interface** in `$HOME/myexpos/xfs-interface` folder
 - **xsm** in `$HOME/myexpos/xsm` folder
 
+!!! note
+    In newer versions of GCC (14+) when executing the ''' make ''' an error is thrown and the executables are not created. This can be fixed by downgrading GCC to     13 or lower.
+
 If the setting up of the system is done correctly the following directories will be created.
 
 ![](../assets/img/xsm_folders.png)


### PR DESCRIPTION
Newer versions of GCC (14 and above) throw errors when the `make` command is executed. Older versions of GCC (13 and below seem to be fine but throw quite a lot of warnings). The GCC issue occurs on native Debian, WSL (Debian), Arch and more.

This just adds info for users to know what the issue most likely is.